### PR TITLE
Delay the runPhantomjs resolve until the process outputs something

### DIFF
--- a/tasks/buster.js
+++ b/tasks/buster.js
@@ -169,7 +169,9 @@ module.exports = function(grunt) {
           grunt.verbose.writeln(data);
         });
 
-        deferred.resolve(server);
+        server.stdout.once('data', function() {
+          deferred.resolve(server);
+        });
       }
     });
 


### PR DESCRIPTION
Hey, awesome stuff here.

Had some problems running this though, got the "No slaves captured, session not created." error almost every time.
runPhantomjs seemed to be resolving before it had captured the buster server.

So I changed it to wait for some output from the process and then resolve. Doesn't feel like the best approach though.. feels overly slow too.

Are you running this part without problems?

Adding this as a pull request for discussion.

Cheers
