### PR TITLE
Auto --server option in client

### DIFF
--- a/tasks/buster.js
+++ b/tasks/buster.js
@@ -16,14 +16,18 @@ module.exports = function(grunt) {
   };
 
   var getArguments = function(cmd) {
+    var port = getConfigSection('server').port || 1111,
+        url = 'http://localhost:' + port,
+        args = [],
+        config = getConfigSection(cmd);
+
     if(cmd === 'phantomjs'){
-      var port = getConfigSection('server').port || 1111,
-          url = 'http://localhost:' + port + '/capture';
-      return [__dirname + '/buster/phantom.js', url];
+      return [__dirname + '/buster/phantom.js', url + '/capture'];
     }
 
-    var args = [],
-        config = getConfigSection(cmd);
+    if(cmd === 'test'){
+      config.server = url;
+    }
 
     for(var arg in config){
       var value = config[arg];


### PR DESCRIPTION
I think that setting default --server option to `buster test` is a good idea. It's less confusing than adding server property in test section in grunt.js file.
