### PR TITLE
Add --server parameter to buster-test call, fix #19 

### DIFF
--- a/tasks/buster.js
+++ b/tasks/buster.js
@@ -25,6 +25,11 @@ module.exports = function(grunt) {
 
     var args = [],
         config = getConfigSection(cmd);
+     
+    if(cmd === 'test'){
+      var port = getConfigSection('server').port || 1111;
+      args.push('--server', 'http://localhost:' + port + '/capture')
+    }
 
     for(var arg in config){
       var value = config[arg];


### PR DESCRIPTION
At the moment the server can be started with any port, but the call to `buster test` is missing the `--server` parameter. This commit will add the missing  parameter to the list for `buster test`
