### PR TITLE
Suggested fix on problem with failed tests and grunt-contrib-watch

### DIFF
--- a/tasks/buster/cmd.js
+++ b/tasks/buster/cmd.js
@@ -113,7 +113,7 @@ exports.runBusterTest = function (args) {
           deferred.resolve();
         } else {
           grunt.event.emit('buster:failure', text);
-          deferred.reject();
+          deferred.resolve();
         }
       });
     }


### PR DESCRIPTION
First, fantastic job on this :-)

I had issues using grunt-buster with grunt-contrib-watch. I had no problems running them together, but when a test fails the "deferred.reject()" call causes the "sequence" in the buster.js task file to run the reject callback, not passing the two server variables needed to stop grunt-server and phantomJS. This causes the "stop()" function in buster.js to actually break since it tries to resolve "results[0]" and "results[1]" of an argument that is undefined.

All of this ends up stopping the grunt task whenever a test fails, not continuing with the watch task to rerun everything when you have fixed the test.

I tried a couple of different solutions, but ended up with the thought that if a test fails it does not mean that the sequence failed. It should still close down the servers.

Hopefully I got this right :-)
