### PR TITLE
Escape characters should only be cleaned for growl

### DIFF
--- a/tasks/buster/cmd.js
+++ b/tasks/buster/cmd.js
@@ -107,7 +107,6 @@ exports.runBusterTest = function (args) {
           text = output[output.length - 2].toString().split(', ').join('\n') +
             output[output.length - 1];
         }
-        text = text.replace(/\u001b\[.*m/g, '').trim();
         if (code === 0) {
           grunt.event.emit('buster:success', text);
           deferred.resolve();

--- a/tasks/buster/growl.js
+++ b/tasks/buster/growl.js
@@ -1,12 +1,17 @@
+var cleanText = function (text)
+{
+  return text.replace(/\u001b\[.*?m/g, '').trim();
+};
+
 var success = function (growl, text) {
-  growl(text, {
+  growl(cleanText(text), {
     title: 'Tests Passed',
     image: __dirname + '/ok.png'
   });
 };
 
 var failure = function (growl, text) {
-  growl(text, {
+  growl(cleanText(text), {
     title: 'Tests Failed',
     image: __dirname + '/error.png'
   });

--- a/test/growl-test.js
+++ b/test/growl-test.js
@@ -44,6 +44,23 @@ buster.testCase('Growl', {
     assert.match(growlSpy.firstCall.args[1], {
       title: 'Tests Failed'
     });
+  },
+
+  'cleans up colors': function () {
+    var growlSpy = this.spy();
+    this.stub(growl, 'requireGrowl', function () {
+      return growlSpy;
+    });
+    growl.init(grunt);
+
+    /* jshint -W100 */
+    /* jshint -W113 */
+    grunt.event.emit('buster:success', 'Results:\n[1m[32m  ✓ resultViewer should exist[0m\n');
+    assert.calledOnceWith(growlSpy, 'Results:\n  ✓ resultViewer should exist');
+
+    assert.match(growlSpy.firstCall.args[1], {
+      title: 'Tests Passed'
+    });
   }
 
 });


### PR DESCRIPTION
- escape characters should be cleaned where they're not supported - i.e. in growl;
- also changing the regex to be non-greedy;

Problem introduced here https://github.com/busterjs/grunt-buster/commit/4690044ebfb0d18e9b70c52e727ba266122e550c to fix #7
