### PR TITLE
Use global binaries, when all else fails

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: node_js
+sudo: false
 node_js:
   - "0.10"
   - "0.12"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,8 @@
 language: node_js
+node_js:
+  - "0.10"
+  - "0.12"
+  - "4"
+  - "5"
+before_install:
+  - npm i -g npm

--- a/package.json
+++ b/package.json
@@ -17,27 +17,27 @@
   "license": "MIT",
   "main": "./tasks/buster.js",
   "engines": {
-    "node": ">= 0.10"
+    "node": ">= 4"
   },
   "scripts": {
     "start": "grunt --force default watch",
     "test": "grunt"
   },
   "devDependencies": {
-    "buster": ">=0.7.6",
-    "grunt": "^0.4.1",
-    "grunt-cli": "^0.1.8",
-    "grunt-contrib-jshint": "^0.11.3",
-    "grunt-contrib-watch": "^0.6.1"
+    "buster": "0.7.x",
+    "grunt": "0.4.x",
+    "grunt-cli": "0.1.x",
+    "grunt-contrib-jshint": "0.11.x",
+    "grunt-contrib-watch": "0.6.x"
   },
   "dependencies": {
-    "resolve-bin": "^0.3.0",
-    "when": "^3.7.4",
-    "which": "^1.2.0"
+    "resolve-bin": "0.3.x",
+    "when": "3.x",
+    "which": "1.x"
   },
   "peerDependencies": {
     "buster": ">=0.7.6",
-    "grunt": "~0.4.0"
+    "grunt": ">=0.4.0"
   },
   "keywords": [
     "gruntplugin",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "license": "MIT",
   "main": "./tasks/buster.js",
   "engines": {
-    "node": ">= 0.8.0"
+    "node": ">= 0.10"
   },
   "scripts": {
     "start": "grunt --force default watch",
@@ -25,17 +25,18 @@
   },
   "devDependencies": {
     "buster": ">=0.7.6",
-    "grunt": "~0.4.1",
-    "grunt-cli": "~0.1.8",
-    "grunt-contrib-jshint": "~0.10.0",
-    "grunt-contrib-watch": "~0.4.0"
+    "grunt": "^0.4.1",
+    "grunt-cli": "^0.1.8",
+    "grunt-contrib-jshint": "^0.11.3",
+    "grunt-contrib-watch": "^0.6.1"
   },
   "dependencies": {
-    "when": "~2.0.0",
-    "resolve-bin": "~0.3.0"
+    "resolve-bin": "^0.3.0",
+    "when": "^3.7.4",
+    "which": "^1.2.0"
   },
   "peerDependencies": {
-    "buster": ">=0.7.x",
+    "buster": ">=0.7.6",
     "grunt": "~0.4.0"
   },
   "keywords": [

--- a/tasks/buster/cmd.js
+++ b/tasks/buster/cmd.js
@@ -2,10 +2,21 @@ var cp = require('child_process');
 var grunt = require('grunt');
 var when = require('when');
 var resolveBin = require('resolve-bin');
+var which = require('which');
+
+var findExecutable = function (moduleName, cmd, cb) {
+  resolveBin(moduleName, {executable:cmd}, function (error, path) {
+    if (error) { // failed to find in [global/local] node_modules - fallback to PATH
+      which(cmd, cb);
+    } else {
+      cb(null, path);
+    }
+  });
+};
 
 exports.run = function (moduleName, cmd, args, callback) {
   callback = callback || function () {};
-  resolveBin(moduleName, { executable: cmd }, function (error, path) {
+  findExecutable(moduleName, cmd, function (error, path) {
     if (error) {
       callback(error);
     } else {
@@ -103,7 +114,7 @@ exports.runPhantomjs = function (args) {
   exports.run('phantomjs', 'phantomjs', args, function (error, phantomProcess) {
     if (error) {
       grunt.log.error(
-        'PhantomJS not found. Run `npm install phantomjs` to install.');
+        'PhantomJS not found. Run `npm install [-g] phantomjs` to install.');
       deferred.reject();
     } else {
       phantomProcess.stdout.on('data', function (data) {

--- a/test/cmd-test.js
+++ b/test/cmd-test.js
@@ -26,10 +26,20 @@ buster.testCase('Cmd', {
       });
     },
 
+    'calls callback with results when a global binary found': function (done) {
+      var spawnStub = this.spawnStub;
+      cmd.run('node', 'node', [ 1, 2, 3 ], function (err) {
+        assert.isNull(err);
+        // node is the only executable I can trust to be in actual PATH - I just dont' know that path, but there should definitely be no error
+        assert.calledOnce(spawnStub);
+        done();
+      });
+    },
+
     'calls callback with error when resolve-bin fails': function (done) {
       cmd.run('no-such-module', 'no-such-file', [], function (err, actualHandle) {
         refute.isNull(err);
-        assert.match(err.message, 'cannot find');
+        assert.match(err.message, 'not found');
         refute(actualHandle);
         done();
       });


### PR DESCRIPTION
Fixes #31 / #33 - globally installed `node_modules` are not (and should not, apparently) be `require`-able, and if you can't `require` it - you can't find it's `.bin` folder, so I added a fallback to look for an executable in the `PATH` (using isaac's `which`).

Also took the liberty to update dependencies and add relevant node versions to `.travis.yml` - although my personal opinion is that 0.10 and 0.12 should be dropped.